### PR TITLE
Auto-save config changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Dostępnę Releasy: https://github.com/LordTricker/LT-Rynek/releases
 | `/ltr remove <przedmiot>` | Usuwa przedmiot z profilu |
 | `/ltr list` | Wyświetla przedmioty w aktywnym profilu |
 | `/ltr pomoc` | Lista dostępnych komend |
-| `/ltr config save` | Zapisuje konfigurację |
+| `/ltr config save` | Ręcznie zapisuje konfigurację (zapis następuje też automatycznie) |
 | `/ltr config reload` | Przeładowuje dane z konfiguracji |
 
 ## 🔧 Instalacja

--- a/src/client/java/pl/lordtricker/ltrynek/client/LtrynekClient.java
+++ b/src/client/java/pl/lordtricker/ltrynek/client/LtrynekClient.java
@@ -2,6 +2,7 @@ package pl.lordtricker.ltrynek.client;
 
 import pl.lordtricker.ltrynek.client.command.ClientCommandRegistration;
 import pl.lordtricker.ltrynek.client.config.ConfigLoader;
+import pl.lordtricker.ltrynek.client.config.ConfigSaver;
 import pl.lordtricker.ltrynek.client.config.PriceEntry;
 import pl.lordtricker.ltrynek.client.config.ServerEntry;
 import pl.lordtricker.ltrynek.client.config.ServersConfig;
@@ -30,27 +31,29 @@ public class LtrynekClient implements ClientModInitializer {
 		}
 		ClientPriceListManager.setActiveProfile(serversConfig.defaultProfile);
 
-		ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> {
-			String address = getServerAddress();
-			ServerEntry entry = findServerEntry(address);
-			if (entry != null) {
-				ClientPriceListManager.setActiveProfile(entry.profileName);
-				if (client.player != null) {
-					String welcomeMsg = Messages.format("player.join", Map.of("profile", entry.profileName));
-					client.player.sendMessage(ColorUtils.translateColorCodes(welcomeMsg), false);
-				}
-			} else {
-				String def = serversConfig.defaultProfile;
-				ClientPriceListManager.setActiveProfile(def);
-				if (client.player != null) {
-					String welcomeMsg = Messages.format("player.join", Map.of("profile", def));
-					client.player.sendMessage(ColorUtils.translateColorCodes(welcomeMsg), false);
-				}
-			}
-		});
+                ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> {
+                        String address = getServerAddress();
+                        ServerEntry entry = findServerEntry(address);
+                        if (entry != null) {
+                                ClientPriceListManager.setActiveProfile(entry.profileName);
+                                if (client.player != null) {
+                                        String welcomeMsg = Messages.format("player.join", Map.of("profile", entry.profileName));
+                                        client.player.sendMessage(ColorUtils.translateColorCodes(welcomeMsg), false);
+                                }
+                        } else {
+                                String def = serversConfig.defaultProfile;
+                                ClientPriceListManager.setActiveProfile(def);
+                                if (client.player != null) {
+                                        String welcomeMsg = Messages.format("player.join", Map.of("profile", def));
+                                        client.player.sendMessage(ColorUtils.translateColorCodes(welcomeMsg), false);
+                                }
+                        }
+                });
 
-		ClientCommandRegistration.registerCommands();
-	}
+                ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> ConfigSaver.save());
+
+                ClientCommandRegistration.registerCommands();
+        }
 
 	private String getServerAddress() {
 		if (MinecraftClient.getInstance().getCurrentServerEntry() != null) {

--- a/src/client/java/pl/lordtricker/ltrynek/client/command/ClientCommandRegistration.java
+++ b/src/client/java/pl/lordtricker/ltrynek/client/command/ClientCommandRegistration.java
@@ -4,6 +4,7 @@ import pl.lordtricker.ltrynek.client.ColorUtils;
 import pl.lordtricker.ltrynek.client.LtrynekClient;
 import pl.lordtricker.ltrynek.client.Messages;
 import pl.lordtricker.ltrynek.client.config.ConfigLoader;
+import pl.lordtricker.ltrynek.client.config.ConfigSaver;
 import pl.lordtricker.ltrynek.client.config.PriceEntry;
 import pl.lordtricker.ltrynek.client.config.ServerEntry;
 import pl.lordtricker.ltrynek.client.price.ClientPriceListManager;
@@ -48,6 +49,8 @@ public class ClientCommandRegistration {
                                         .executes(ctx -> {
                                             String profile = StringArgumentType.getString(ctx, "profile");
                                             ClientPriceListManager.setActiveProfile(profile);
+                                            LtrynekClient.serversConfig.defaultProfile = profile;
+                                            ConfigSaver.save();
 
                                             String msg = Messages.format("command.defaultprofile.success", Map.of("profile", profile));
                                             ctx.getSource().sendFeedback(ColorUtils.translateColorCodes(msg));
@@ -115,6 +118,7 @@ public class ClientCommandRegistration {
                                                                 "profile", activeProfile
                                                         ));
                                                         ctx.getSource().sendFeedback(ColorUtils.translateColorCodes(msg));
+                                                        ConfigSaver.save();
                                                     } catch (NumberFormatException e) {
                                                         ctx.getSource().sendError(Text.literal("Invalid price format: " + maxPriceStr));
                                                     }
@@ -137,6 +141,7 @@ public class ClientCommandRegistration {
                                                     "profile", activeProfile
                                             ));
                                             ctx.getSource().sendFeedback(ColorUtils.translateColorCodes(msg));
+                                            ConfigSaver.save();
                                             return 1;
                                         })
                                 )
@@ -227,9 +232,7 @@ public class ClientCommandRegistration {
                         .then(ClientCommandManager.literal("config")
                                 .then(ClientCommandManager.literal("save")
                                         .executes(ctx -> {
-                                            syncMemoryToConfig();
-
-                                            ConfigLoader.saveConfig(LtrynekClient.serversConfig);
+                                            ConfigSaver.save();
 
                                             String msg = Messages.get("command.config.save.success");
                                             ctx.getSource().sendFeedback(ColorUtils.translateColorCodes(msg));
@@ -254,36 +257,6 @@ public class ClientCommandRegistration {
     }
 
     /**
-     * Synchronizuje dane z pamięci (ClientPriceListManager) do obiektu LtrynekClient.serversConfig,
-     * tak aby /ltrynek config save mógł zapisać te zmiany do pliku.
-     */
-    private static void syncMemoryToConfig() {
-        for (ServerEntry entry : LtrynekClient.serversConfig.servers) {
-            entry.prices.clear();
-        }
-        Map<String, Map<String, Double>> allProfiles = ClientPriceListManager.getAllProfiles();
-        for (Map.Entry<String, Map<String, Double>> profEntry : allProfiles.entrySet()) {
-            String profileName = profEntry.getKey();
-            Map<String, Double> items = profEntry.getValue();
-
-            ServerEntry se = findServerEntryByProfile(profileName);
-            if (se == null) {
-                continue;
-            }
-
-            for (Map.Entry<String, Double> itemEntry : items.entrySet()) {
-                String itemName = itemEntry.getKey();
-                double maxPrice = itemEntry.getValue();
-
-                PriceEntry pe = new PriceEntry();
-                pe.name = itemName;
-                pe.maxPrice = maxPrice;
-                se.prices.add(pe);
-            }
-        }
-    }
-
-    /**
      * Czyści i na nowo inicjalizuje ClientPriceListManager z LtrynekClient.serversConfig.
      */
     private static void reinitProfilesFromConfig() {
@@ -296,15 +269,4 @@ public class ClientCommandRegistration {
         ClientPriceListManager.setActiveProfile(LtrynekClient.serversConfig.defaultProfile);
     }
 
-    /**
-     * Znajduje ServerEntry w LtrynekClient.serversConfig dla danego profileName.
-     */
-    private static ServerEntry findServerEntryByProfile(String profileName) {
-        for (ServerEntry entry : LtrynekClient.serversConfig.servers) {
-            if (entry.profileName.equals(profileName)) {
-                return entry;
-            }
-        }
-        return null;
-    }
 }

--- a/src/client/java/pl/lordtricker/ltrynek/client/config/ConfigSaver.java
+++ b/src/client/java/pl/lordtricker/ltrynek/client/config/ConfigSaver.java
@@ -1,0 +1,64 @@
+package pl.lordtricker.ltrynek.client.config;
+
+import pl.lordtricker.ltrynek.client.LtrynekClient;
+import pl.lordtricker.ltrynek.client.price.ClientPriceListManager;
+
+import java.util.Map;
+
+/**
+ * Utility class that synchronizes in-memory price list data with the config file
+ * and persists it to disk.
+ */
+public class ConfigSaver {
+    /**
+     * Synchronizes data from ClientPriceListManager to LtrynekClient.serversConfig
+     * and writes the result to the config file.
+     */
+    public static void save() {
+        syncMemoryToConfig();
+        ConfigLoader.saveConfig(LtrynekClient.serversConfig);
+    }
+
+    /**
+     * Synchronizes data from memory (ClientPriceListManager) to the serversConfig object,
+     * so that it can be saved to the config file.
+     */
+    public static void syncMemoryToConfig() {
+        for (ServerEntry entry : LtrynekClient.serversConfig.servers) {
+            entry.prices.clear();
+        }
+        Map<String, Map<String, Double>> allProfiles = ClientPriceListManager.getAllProfiles();
+        for (Map.Entry<String, Map<String, Double>> profEntry : allProfiles.entrySet()) {
+            String profileName = profEntry.getKey();
+            Map<String, Double> items = profEntry.getValue();
+
+            ServerEntry se = findServerEntryByProfile(profileName);
+            if (se == null) {
+                continue;
+            }
+
+            for (Map.Entry<String, Double> itemEntry : items.entrySet()) {
+                String itemName = itemEntry.getKey();
+                double maxPrice = itemEntry.getValue();
+
+                PriceEntry pe = new PriceEntry();
+                pe.name = itemName;
+                pe.maxPrice = maxPrice;
+                se.prices.add(pe);
+            }
+        }
+    }
+
+    /**
+     * Finds the ServerEntry in serversConfig for the given profile name.
+     */
+    private static ServerEntry findServerEntryByProfile(String profileName) {
+        for (ServerEntry entry : LtrynekClient.serversConfig.servers) {
+            if (entry.profileName.equals(profileName)) {
+                return entry;
+            }
+        }
+        return null;
+    }
+}
+


### PR DESCRIPTION
## Summary
- automatically sync and write config whenever profiles or items change
- persist config when disconnecting from a server
- document that config is saved automatically

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6898ea391774832497becb5d9f7a9b81